### PR TITLE
Improve SSE/event handling, plugin toggle persistence, first-run signing & graceful shutdown

### DIFF
--- a/build.py
+++ b/build.py
@@ -8,11 +8,16 @@ SIGNING_MODULE = ROOT / "notmyfault" / "signing_keys.py"
 PLUGIN_DIRS = [("actions", "action.json"), ("triggers", "trigger.json")]
 
 def _get_crypto():
-    from cryptography.hazmat.primitives.asymmetric import ed25519
-    from cryptography.hazmat.primitives.serialization import (
-        load_ssh_private_key, load_ssh_public_key, Encoding, PrivateFormat, PublicFormat, NoEncryption, BestAvailableEncryption, load_pem_private_key
-    )
-    from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PrivateKey
+    try:
+        from cryptography.hazmat.primitives.asymmetric import ed25519
+        from cryptography.hazmat.primitives.serialization import (
+            load_ssh_private_key, load_ssh_public_key, Encoding, PrivateFormat, PublicFormat, NoEncryption, BestAvailableEncryption, load_pem_private_key
+        )
+        from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PrivateKey
+    except ImportError:
+        print("! 缺少 cryptography 依赖，无法生成或验证插件签名")
+        print("  请先安装依赖后重试: python -m pip install cryptography")
+        raise SystemExit(1)
     return ed25519, load_ssh_private_key, load_ssh_public_key, Encoding, PrivateFormat, PublicFormat, NoEncryption, BestAvailableEncryption, load_pem_private_key, Ed25519PrivateKey
 
 

--- a/notmyfault/actions/bluetooth_toggle/action.json
+++ b/notmyfault/actions/bluetooth_toggle/action.json
@@ -19,6 +19,5 @@
                 "off"
             ]
         }
-    ],
-    "origin": "builtin"
+    ]
 }

--- a/notmyfault/actions/kill_process/action.json
+++ b/notmyfault/actions/kill_process/action.json
@@ -12,6 +12,5 @@
             "default": "",
             "placeholder": "如 Notepad.exe、WeChat.exe"
         }
-    ],
-    "origin": "builtin"
+    ]
 }

--- a/notmyfault/actions/launch_program/action.json
+++ b/notmyfault/actions/launch_program/action.json
@@ -19,6 +19,5 @@
             "default": "",
             "placeholder": "可选，命令行参数"
         }
-    ],
-    "origin": "builtin"
+    ]
 }

--- a/notmyfault/actions/lock_screen/action.json
+++ b/notmyfault/actions/lock_screen/action.json
@@ -4,6 +4,5 @@
     "description": "立即锁定 Windows 工作站",
     "version_code": 1,
     "enabled": true,
-    "params": [],
-    "origin": "builtin"
+    "params": []
 }

--- a/notmyfault/actions/notify/action.json
+++ b/notmyfault/actions/notify/action.json
@@ -19,6 +19,5 @@
             "default": "",
             "placeholder": "通知的正文内容"
         }
-    ],
-    "origin": "builtin"
+    ]
 }

--- a/notmyfault/actions/run_powershell/action.json
+++ b/notmyfault/actions/run_powershell/action.json
@@ -12,6 +12,5 @@
             "default": "",
             "placeholder": "要执行的 PowerShell 命令"
         }
-    ],
-    "origin": "builtin"
+    ]
 }

--- a/notmyfault/actions/set_volume/action.json
+++ b/notmyfault/actions/set_volume/action.json
@@ -17,6 +17,5 @@
                 "mute"
             ]
         }
-    ],
-    "origin": "builtin"
+    ]
 }

--- a/notmyfault/api_server.py
+++ b/notmyfault/api_server.py
@@ -10,7 +10,6 @@ NotmyFault HTTP API 服务器
 import json
 import secrets
 import os
-import queue
 import sys
 import threading
 import time
@@ -63,7 +62,7 @@ class EngineAPI:
 
     def __init__(self, engine_runner: EngineRunnerLike):
         self._engine = engine_runner
-        self._subscribers: list[queue.Queue] = []
+        self._subscribers: list[tuple[Any, Any]] = []
         self._sub_lock = threading.Lock()
         self._server = None
         self._engine_ref = None
@@ -98,14 +97,21 @@ class EngineAPI:
     def push_event(self, event_type: str, data: Dict[str, Any]):
         packet = {"type": event_type, "data": data, "ts": time.time()}
         with self._sub_lock:
-            dead = []
-            for q in self._subscribers:
+            subscribers = list(self._subscribers)
+
+        for loop, q in subscribers:
+            def _push(target=q):
                 try:
-                    q.put_nowait(packet)
-                except queue.Full:
-                    dead.append(q)
-            for q in dead:
-                self._subscribers.remove(q)
+                    target.put_nowait(packet)
+                except Exception:
+                    pass
+
+            try:
+                loop.call_soon_threadsafe(_push)
+            except RuntimeError:
+                with self._sub_lock:
+                    if (loop, q) in self._subscribers:
+                        self._subscribers.remove((loop, q))
 
     # ---- 插件扫描 (供 /api/plugins 使用) --------------------------------
 
@@ -122,6 +128,7 @@ class EngineAPI:
     def _list_all_plugins(self) -> Dict[str, Any]:
         base = os.path.dirname(__file__)
         user_dir = self._get_user_plugins_dir()
+        disabled_plugins = self._load_config().get("disabled_plugins", {})
 
         result: Dict[str, Dict] = {"triggers": {}, "actions": {}}
         for ptype in ("triggers", "actions"):
@@ -129,6 +136,8 @@ class EngineAPI:
             # builtin
             for pid, meta in scan_plugins(base, ptype, json_name).items():
                 meta["origin"] = meta.get("origin", "builtin")
+                if pid in disabled_plugins.get(ptype, []):
+                    meta["enabled"] = False
                 result[ptype][pid] = meta
             # user
             if os.path.isdir(user_dir):
@@ -155,7 +164,7 @@ class EngineAPI:
         user_dir = self._get_user_plugins_dir()
         json_name = "trigger.json" if ptype == "triggers" else "action.json"
 
-        for root in (base, user_dir):
+        for root in (user_dir,):
             json_path = os.path.join(root, ptype, pid, json_name)
             if os.path.exists(json_path):
                 try:
@@ -166,12 +175,29 @@ class EngineAPI:
                     with open(json_path, "w", encoding="utf-8") as f:
                         json.dump(meta, f, ensure_ascii=False, indent=2)
                     return {"ok": True, "enabled": meta["enabled"],
-                            "origin": "builtin" if root == base else "user",
+                            "origin": "user",
                             "restart_required": True}
                 except (json.JSONDecodeError, OSError) as e:
                     return {"ok": False, "error": str(e)}
 
-        return {"ok": False, "error": "插件不存在"}
+        builtin_json = os.path.join(base, ptype, pid, json_name)
+        if not os.path.exists(builtin_json):
+            return {"ok": False, "error": "插件不存在"}
+
+        config = self._load_config()
+        disabled_plugins = config.setdefault("disabled_plugins", {})
+        disabled = set(disabled_plugins.get(ptype, []))
+        if pid in disabled:
+            disabled.remove(pid)
+            enabled = True
+        else:
+            disabled.add(pid)
+            enabled = False
+        disabled_plugins[ptype] = sorted(disabled)
+
+        if not self._save_config(config):
+            return {"ok": False, "error": "写入配置文件失败"}
+        return {"ok": True, "enabled": enabled, "origin": "builtin", "restart_required": True}
 
     def _uninstall_plugin(self, ptype: str, pid: str) -> dict:
         user_dir = self._get_user_plugins_dir()
@@ -260,8 +286,9 @@ class EngineAPI:
             config = self._load_config()
             rules = config.get("rules", [])
             return {
-                "running": True,
+                "running": self._engine.engine_running,
                 "engine_running": self._engine.engine_running,
+                "api_alive": True,
                 "pid": os.getpid(),
                 "rules_count": len(rules),
                 "triggers_count": len(set(
@@ -298,6 +325,9 @@ class EngineAPI:
             new_config = {
                 "rules": body.get("rules", []),
             }
+            current_config = self._load_config()
+            if "disabled_plugins" in current_config:
+                new_config["disabled_plugins"] = current_config["disabled_plugins"]
 
             ok = self._save_config(new_config)
             if ok:
@@ -375,7 +405,8 @@ class EngineAPI:
                         return JSONResponse({"ok": False, "error": "插件元数据 JSON 损坏或缺失"}, status_code=400)
 
                     from notmyfault.plugin_schema import validate_plugin_meta
-                    ok, errors = validate_plugin_meta(meta, ptype)
+                    plugin_type = "trigger" if ptype == "triggers" else "action"
+                    ok, errors = validate_plugin_meta(meta, plugin_type)
                     if not ok:
                         return JSONResponse({"ok": False, "error": "schema 校验失败: " + "; ".join(errors[:3])}, status_code=400)
 
@@ -448,36 +479,31 @@ class EngineAPI:
         @app.get("/api/events")
         async def event_stream(request: Request):
             async def generate():
-                client_queue: queue.Queue = queue.Queue(maxsize=200)
+                import asyncio
+
+                loop = asyncio.get_running_loop()
+                client_queue: asyncio.Queue = asyncio.Queue(maxsize=200)
+                subscriber = (loop, client_queue)
                 with self._sub_lock:
-                    self._subscribers.append(client_queue)
+                    self._subscribers.append(subscriber)
 
                 try:
-                    import asyncio
-                    loop = asyncio.get_event_loop()
-
                     while True:
                         if await request.is_disconnected():
                             break
 
-                        drained = False
-                        while True:
-                            try:
-                                event = client_queue.get_nowait()
-                                drained = True
-                                yield f"event: {event['type']}\n"
-                                yield f"data: {json.dumps(event['data'], ensure_ascii=False)}\n\n"
-                            except queue.Empty:
-                                break
-
-                        if drained:
+                        try:
+                            event = await asyncio.wait_for(client_queue.get(), timeout=15)
+                        except asyncio.TimeoutError:
+                            yield ": keep-alive\n\n"
                             continue
 
-                        await asyncio.sleep(0.5)
+                        yield f"event: {event['type']}\n"
+                        yield f"data: {json.dumps(event['data'], ensure_ascii=False)}\n\n"
                 finally:
                     with self._sub_lock:
-                        if client_queue in self._subscribers:
-                            self._subscribers.remove(client_queue)
+                        if subscriber in self._subscribers:
+                            self._subscribers.remove(subscriber)
 
             return StreamingResponse(
                 generate(),

--- a/notmyfault/app.py
+++ b/notmyfault/app.py
@@ -1,6 +1,8 @@
 import os
+import subprocess
 import sys
 import threading
+from pathlib import Path
 from typing import Any, Callable, Dict, Optional
 
 from .config import get_config
@@ -19,9 +21,46 @@ def _get_plugin_paths():
     return paths
 
 
+def _ensure_first_run_build() -> None:
+    """源码首次运行时自动初始化签名并签署内置插件。"""
+    if getattr(sys, "frozen", False):
+        return
+
+    root = Path(__file__).resolve().parent.parent
+    build_py = root / "build.py"
+    if not build_py.exists():
+        return
+
+    plugin_jsons = list((root / "notmyfault" / "actions").glob("*/action.json"))
+    plugin_jsons += list((root / "notmyfault" / "triggers").glob("*/trigger.json"))
+    if not plugin_jsons:
+        return
+
+    unsigned = [p for p in plugin_jsons if not (p.parent / "signature.sig").exists()]
+    build_json = root / "build.json"
+    if not unsigned and build_json.exists():
+        return
+
+    commands = []
+    if not (root / ".private" / "signing_private_key.pem").exists():
+        commands.append([sys.executable, str(build_py), "init-keys", "--builtin"])
+    commands.append([sys.executable, str(build_py), "sign"])
+    if not build_json.exists():
+        commands.append([sys.executable, str(build_py), "build"])
+
+    for cmd in commands:
+        try:
+            subprocess.run(cmd, cwd=str(root), check=True, timeout=60)
+        except (OSError, subprocess.SubprocessError) as exc:
+            print(f"[App] 首次运行自动构建失败: {' '.join(cmd)}: {exc}")
+            os.environ.setdefault("NOTMYFAULT_MODE", "develop")
+            return
+
+
 def create_engine(
     on_event: Optional[Callable[[str, Dict[str, Any]], None]] = None,
 ) -> AutomationEngine:
+    _ensure_first_run_build()
     config = get_config()
     engine = AutomationEngine(config, on_event=on_event)
     engine.auto_load(_get_plugin_paths())

--- a/notmyfault/config.py
+++ b/notmyfault/config.py
@@ -8,6 +8,10 @@ import sys
 from typing import Any, Dict, List
 
 DEFAULT_CONFIG: Dict[str, Any] = {
+    "disabled_plugins": {
+        "triggers": [],
+        "actions": [],
+    },
     "rules": [
         {
             "name": "微信音量规则",

--- a/notmyfault/engine.py
+++ b/notmyfault/engine.py
@@ -450,6 +450,13 @@ class AutomationEngine:
                 )
                 continue
 
+            disabled_plugins = self.config.get("disabled_plugins", {})
+            if plugin_id in disabled_plugins.get(plugins_dir, []):
+                print(
+                    f"[Engine] 插件 \"{plugin_id}\" ({meta['name']}) 已由用户配置禁用，跳过"
+                )
+                continue
+
             # --- Python 模块加载 ---
             module_name = f"{module_prefix}{plugin_id}"
             spec = importlib.util.spec_from_file_location(module_name, py_file)

--- a/notmyfault/triggers/bluetooth_device/trigger.json
+++ b/notmyfault/triggers/bluetooth_device/trigger.json
@@ -23,6 +23,5 @@
                 "disconnected"
             ]
         }
-    ],
-    "origin": "builtin"
+    ]
 }

--- a/notmyfault/triggers/bluetooth_device/trigger.py
+++ b/notmyfault/triggers/bluetooth_device/trigger.py
@@ -137,7 +137,7 @@ def run(meta, config_list, emit_event, shutdown_event):
 
     while not shutdown_event.is_set():
         try:
-            time.sleep(3)
+            shutdown_event.wait(3)
             scan_count += 1
 
             current_devices, errors = _get_connected_devices()

--- a/notmyfault/triggers/idle_detect/trigger.json
+++ b/notmyfault/triggers/idle_detect/trigger.json
@@ -13,6 +13,5 @@
             "default": "300",
             "placeholder": "空闲多少秒后触发（默认300秒=5分钟）"
         }
-    ],
-    "origin": "builtin"
+    ]
 }

--- a/notmyfault/triggers/idle_detect/trigger.py
+++ b/notmyfault/triggers/idle_detect/trigger.py
@@ -51,4 +51,4 @@ def run(meta, config_list, emit_event, shutdown_event):
         except Exception as e:
             print(f"[Trigger:{trigger_id}] 扫描出错: {e}")
 
-        time.sleep(2)
+        shutdown_event.wait(2)

--- a/notmyfault/triggers/process_state/trigger.json
+++ b/notmyfault/triggers/process_state/trigger.json
@@ -23,6 +23,5 @@
                 "stopped"
             ]
         }
-    ],
-    "origin": "builtin"
+    ]
 }

--- a/notmyfault/triggers/process_state/trigger.py
+++ b/notmyfault/triggers/process_state/trigger.py
@@ -62,4 +62,4 @@ def run(trigger_info, config_list, emit_event, shutdown_event):
                     "state": current_state,
                 })
 
-        time.sleep(poll_interval)
+        shutdown_event.wait(poll_interval)

--- a/notmyfault/triggers/time_schedule/trigger.json
+++ b/notmyfault/triggers/time_schedule/trigger.json
@@ -13,6 +13,5 @@
             "default": "22:00",
             "placeholder": "HH:MM 格式，如 08:30、22:00"
         }
-    ],
-    "origin": "builtin"
+    ]
 }

--- a/notmyfault/triggers/time_schedule/trigger.py
+++ b/notmyfault/triggers/time_schedule/trigger.py
@@ -39,4 +39,4 @@ def run(meta, config_list, emit_event, shutdown_event):
         except Exception as e:
             print(f"[Trigger:{trigger_id}] 检查出错: {e}")
 
-        time.sleep(30)
+        shutdown_event.wait(30)

--- a/notmyfault/triggers/usb_insert/trigger.json
+++ b/notmyfault/triggers/usb_insert/trigger.json
@@ -13,6 +13,5 @@
             "default": "ANY",
             "placeholder": "ANY 匹配任意盘符，或指定如 E:"
         }
-    ],
-    "origin": "builtin"
+    ]
 }

--- a/notmyfault/triggers/usb_insert/trigger.py
+++ b/notmyfault/triggers/usb_insert/trigger.py
@@ -52,4 +52,4 @@ def run(meta, config_list, emit_event, shutdown_event):
             print(f"[Trigger:{trigger_id}] 哎呀，扫描U盘的时候报错啦: {e}")
 
         # 每3秒扫描一次就足够啦
-        time.sleep(3)
+        shutdown_event.wait(3)

--- a/notmyfault/triggers/window_title/trigger.json
+++ b/notmyfault/triggers/window_title/trigger.json
@@ -23,6 +23,5 @@
                 "closed"
             ]
         }
-    ],
-    "origin": "builtin"
+    ]
 }

--- a/notmyfault/triggers/window_title/trigger.py
+++ b/notmyfault/triggers/window_title/trigger.py
@@ -72,4 +72,4 @@ def run(meta, config_list, emit_event, shutdown_event):
         except Exception as e:
             print(f"[Trigger:{trigger_id}] 扫描出错: {e}")
 
-        time.sleep(3)
+        shutdown_event.wait(3)


### PR DESCRIPTION
### Motivation
- Make server-side event delivery more robust and thread-safe for asyncio-based SSE clients.  
- Persist user plugin enable/disable choices instead of modifying builtin metadata files.  
- Automate initial signing/build steps on first run and fail fast with a clear message when `cryptography` is missing.  
- Allow triggers and engine to shut down promptly by replacing blocking `time.sleep` with interruptible waits.

### Description
- Wrapped `cryptography` imports in `_get_crypto` with a clear error message and exit when missing, and adjusted error handling in `build.py`.  
- Added `_ensure_first_run_build` in `notmyfault/app.py` to run `build.py init-keys`, `sign`, and `build` automatically on first source run.  
- Refactored SSE subscription model in `notmyfault/api_server.py` to store `(loop, queue)` tuples, use `asyncio.Queue`, push events with `loop.call_soon_threadsafe`, and make the SSE generator use `await queue.get()` with a timeout keep-alive.  
- Made plugin toggling persist user-disabled builtin plugins in configuration via a new `disabled_plugins` structure in `DEFAULT_CONFIG` and implemented read/write support in `_list_all_plugins`, `_toggle_plugin`, and engine loading logic.  
- Updated engine to skip plugins listed in `config['disabled_plugins']` when loading.  
- Replaced blocking `time.sleep(...)` calls in multiple triggers with `shutdown_event.wait(...)` to respond quickly to shutdown requests.  
- Adjusted a few API endpoints: `engine/status` now returns accurate `running`/`engine_running` and an `api_alive` flag, and plugin upload validation calls the corrected `validate_plugin_meta` parameter.  
- Removed hardcoded `

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a5780ece71c8324bab5f5ac64882479)