### PR TITLE
test: 等待界面过渡完成，修复两处 Dashboard 冒烟测试误报

### DIFF
--- a/dashboard/tests/mount.mjs
+++ b/dashboard/tests/mount.mjs
@@ -1213,20 +1213,21 @@ if (!aiDraftReviewOnlyOk) {
 
 mockAiDraftError = 'AI 模拟错误：请稍后重试'
 await sendNaturalDraft('继续说明这个草稿')
-await new Promise(r => setTimeout(r, 50))
+const retryButton = await waitFor('.ai-error-retry:not(:disabled)')
 const failedTurn = aiDraftCalls.at(-1)
 const requestHasNoRemovedPluginFields = !('consent' in failedTurn)
 const visibleErrorMessages = [...document.querySelectorAll('.natural-draft-conversation .ai-message')]
   .filter(message => message.textContent.includes(mockAiDraftError))
-const retryButton = await waitFor('.ai-error-retry:not(:disabled)')
 const errorCallCount = aiDraftCalls.length
 retryButton?.click()
-await new Promise(r => setTimeout(r, 50))
+// TransitionGroup 会短暂保留离场消息；等旧错误退出后再检查重试结果。
+const retryCompleted = await waitFor(() => visibleErrorMessages.every(message => !message.isConnected)
+  && document.querySelector('.ai-error-retry:not(:disabled)'))
 const retryTurn = aiDraftCalls.at(-1)
 const errorRetryKeepsOneRequest = aiDraftCalls.length === errorCallCount + 1
   && retryTurn?.messages?.at(-1)?.content === '继续说明这个草稿'
   && retryTurn.messages.filter(message => message.content === '继续说明这个草稿').length === 1
-const errorAnnouncedOnce = visibleErrorMessages.length === 1
+const errorAnnouncedOnce = !!retryCompleted && visibleErrorMessages.length === 1
   && document.querySelectorAll('.ai-error[role="alert"]').length === 1
   && errorRetryKeepsOneRequest
 await new Promise(r => setTimeout(r, 550))
@@ -1425,7 +1426,8 @@ addFailureAction?.click()
 await new Promise(r => setTimeout(r, 20))
 const failurePickerOk = document.querySelector('.plugin-picker-dialog')?.textContent.includes('添加补救动作')
 document.querySelector('.plugin-picker-item')?.click()
-await new Promise(r => setTimeout(r, 40))
+// 节点设置使用 out-in 过渡，先等主动作面板换成补救动作面板。
+await waitFor(() => document.querySelector('.node-inspector')?.textContent.includes('这个动作只会在上方主动作最终失败时执行'))
 const controlLabels = [...document.querySelectorAll('.node-link-label')].map(label => label.textContent)
 const failureBranchOk = failurePickerOk
   && document.querySelectorAll('.graph-node-failure-action').length === 1


### PR DESCRIPTION
Dashboard 冒烟测试在固定等待 40/50ms 后读取 DOM，Vue 过渡稍慢时会把离场错误消息计作重复提示，或在添加补救动作后读到旧设置面板，导致正常流程被判为失败。

本 PR 只调整 dashboard/tests/mount.mjs 的两处同步：复用已有 waitFor，等待旧错误消息移出 DOM、新重试按钮可用，以及补救动作面板出现。保留请求次数、唯一错误提示、图节点、连线和保存内容等原断言；等待仍有 1000ms 上限。

验证：
- 两处都用 40ms requestAnimationFrame 回调延迟做受控复现，修改前失败、修改后通过。
- 最终完整 npm test 和 clean Vite build 通过。
- 按 DEVELOPMENT 执行 Python 全套：895 passed、58 skipped、2 deselected、16 failed、4 errors；其中有缺少 webview 及签名/UIA相关问题，本 PR 未修改 Python，未将该结果表述为通过。

改动规模：1 个既有文件，7 行增加、5 行删除。没有新增测试用例、框架或产品功能。